### PR TITLE
Php8.5 patch

### DIFF
--- a/src/DateTimeInterface.php
+++ b/src/DateTimeInterface.php
@@ -110,5 +110,5 @@ interface DateTimeInterface extends \DateTimeInterface {
 	 * @param \DateTimeZone $timezone A DateTimeZone object representing the desired time zone.
 	 * @return self|false
 	 */
-	public static function create_from_format( $format, $time, \DateTimeZone $timezone = null );
+	public static function create_from_format( $format, $time, ?\DateTimeZone $timezone = null );
 }

--- a/src/DateTimeInterface.php
+++ b/src/DateTimeInterface.php
@@ -105,9 +105,9 @@ interface DateTimeInterface extends \DateTimeInterface {
 	 * @link https://www.php.net/manual/en/datetime.createfromformat.php
 	 * @link https://www.php.net/manual/en/datetimeimmutable.createfromformat.php
 	 *
-	 * @param string        $format   Format accepted by date().
-	 * @param string        $time     String representing the time.
-	 * @param \DateTimeZone $timezone A DateTimeZone object representing the desired time zone.
+	 * @param string             $format   Format accepted by date().
+	 * @param string             $time     String representing the time.
+	 * @param \DateTimeZone|null $timezone A DateTimeZone object representing the desired time zone.
 	 * @return self|false
 	 */
 	public static function create_from_format( $format, $time, ?\DateTimeZone $timezone = null );

--- a/src/DateTimeTrait.php
+++ b/src/DateTimeTrait.php
@@ -280,7 +280,7 @@ trait DateTimeTrait {
 	 * @return self|false
 	 */
 	#[\ReturnTypeWillChange]
-	public static function create_from_format( $format, $time, \DateTimeZone $timezone = null ) {
+	public static function create_from_format( $format, $time, ?\DateTimeZone $timezone = null ) {
 		/*
 		 * In PHP 5.6 or lower it's not possible to pass in an empty (null) timezone object.
 		 * This will result in a `DateTime::createFromFormat() expects parameter 3 to be DateTimeZone, null given` error.

--- a/src/DateTimeTrait.php
+++ b/src/DateTimeTrait.php
@@ -273,9 +273,9 @@ trait DateTimeTrait {
 	 *
 	 * @since 1.0.1
 	 *
-	 * @param string        $format   Format accepted by date().
-	 * @param string        $time     String representing the time.
-	 * @param \DateTimeZone $timezone A DateTimeZone object representing the desired time zone.
+	 * @param string             $format   Format accepted by date().
+	 * @param string             $time     String representing the time.
+	 * @param \DateTimeZone|null $timezone A DateTimeZone object representing the desired time zone.
 	 *
 	 * @return self|false
 	 */


### PR DESCRIPTION
Fixed PHP 8.5 Deprecated Code.

```
[23-Feb-2026 19:19:34 UTC] PHP Deprecated:  Pronamic\WordPress\DateTime\DateTimeTrait::create_from_format(): Implicitly marking parameter $timezone as nullable is deprecated, the explicit nullable type must be used instead in \pronamic\wp-datetime\src\DateTimeTrait.php on line 283
[23-Feb-2026 19:19:34 UTC] PHP Deprecated:  Pronamic\WordPress\DateTime\DateTimeInterface::create_from_format(): Implicitly marking parameter $timezone as nullable is deprecated, the explicit nullable type must be used instead in \pronamic\wp-datetime\src\DateTimeInterface.php on line 113

```